### PR TITLE
Remove GHA scheduling for external scheduling

### DIFF
--- a/.github/workflows/break.yml
+++ b/.github/workflows/break.yml
@@ -2,8 +2,6 @@
 name: Break Reminder
 
 on:
-  schedule:
-    - cron: '10 20 * * 1-5'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/eod.yml
+++ b/.github/workflows/eod.yml
@@ -2,8 +2,6 @@
 name: End of Day Reminder
 
 on:
-  schedule:
-    - cron: '10 1 * * 2-6'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/lunch.yml
+++ b/.github/workflows/lunch.yml
@@ -2,8 +2,6 @@
 name: Lunch Reminder
 
 on:
-  schedule:
-    - cron: '45 19 * * 1-5'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/standup.yml
+++ b/.github/workflows/standup.yml
@@ -2,9 +2,6 @@
 name: Standup Reminder
 
 on:
-  schedule:
-    - cron: '10 17-23 * * *'
-    - cron: '10 0-1 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### Description
To get around the flakiness of GHA scheduling, I am now using cron-job.org and Pipedream as the proxy. This will give me much greater reliability for my workflow scheduling.